### PR TITLE
Handle error in replication documents

### DIFF
--- a/src/couch_replicator_docs.erl
+++ b/src/couch_replicator_docs.erl
@@ -76,7 +76,7 @@ update_doc_process_error(DbName, DocId, Error) ->
     end,
     couch_log:error("Error processing replication doc `~s`: ~s", [DocId, Reason]),
     update_rep_doc(DbName, DocId, [
-        {<<"_replication_state">>, <<"error">>},
+        {<<"_replication_state">>, <<"failed">>},
         {<<"_replication_state_reason">>, Reason}]).
 
 


### PR DESCRIPTION
Retry on  `error` state. Those are documents updated by the older
replicator code. Some of those errors were transient.

Introduce `failed` state for documents which fail to parse as valid
replicator #rep{} records and can't even be submitted as jobs to job
scheduler. On this state, don't attempt to start replication.
