### PR TITLE
Add exponential backoff for erroring jobs

### DIFF
--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -313,13 +313,12 @@ running_job_count() ->
 
 -spec running_jobs() -> [#job{}].
 running_jobs() ->
-    ets:tab2list(?MODULE) -- pending_jobs().
+    ets:select(?MODULE, [{#job{pid = '$1', _='_'}, [{is_pid, '$1'}], ['$_']}]).
 
 
 -spec pending_job_count() -> non_neg_integer().
 pending_job_count() ->
-    MatchSpec = [{#job{pid='$1', _='_'}, [{'not', {'is_pid', '$1'}}], [true]}],
-    ets:select_count(?MODULE, MatchSpec).
+    ets:select_count(?MODULE, [{#job{pid=undefined, _='_'}, [], [true]}]).
 
 
 -spec pending_jobs() -> [#job{}].

--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -35,14 +35,14 @@
 -type history() :: [Events :: event()].
 
 %% definitions
--define(MAX_HISTORY, 20).
 -define(MAX_BACKOFF_EXPONENT, 10).
 -define(BACKOFF_INTERVAL_MICROS, 30 * 1000 * 1000).
 
 -define(DEFAULT_MAX_JOBS, 100).
 -define(DEFAULT_MAX_CHURN, 20).
+-define(DEFAULT_MAX_HISTORY, 20).
 -define(DEFAULT_SCHEDULER_INTERVAL, 60000).
--record(state, {interval, timer, max_jobs, max_churn}).
+-record(state, {interval, timer, max_jobs, max_churn, max_history}).
 -record(job, {
           id :: job_id(),
           rep :: #rep{},
@@ -84,8 +84,16 @@ init(_) ->
     Interval = config:get_integer("replicator", "interval", ?DEFAULT_SCHEDULER_INTERVAL),
     MaxJobs = config:get_integer("replicator", "max_jobs", ?DEFAULT_MAX_JOBS),
     MaxChurn = config:get_integer("replicator", "max_churn", ?DEFAULT_MAX_CHURN),
+    MaxHistory = config:get_integer("replicator", "max_history", ?DEFAULT_MAX_HISTORY),
     {ok, Timer} = timer:send_after(Interval, reschedule),
-    {ok, #state{interval = Interval, max_jobs = MaxJobs, max_churn = MaxChurn, timer = Timer}}.
+    State = #state{
+        interval = Interval,
+        max_jobs = MaxJobs,
+        max_churn = MaxChurn,
+        max_history = MaxHistory,
+        timer = Timer
+    },
+    {ok, State}.
 
 
 handle_call({add_job, Job}, _From, State) ->
@@ -93,7 +101,7 @@ handle_call({add_job, Job}, _From, State) ->
         true ->
             case running_job_count() of
                 RunningJobs when RunningJobs < State#state.max_jobs ->
-                    start_job_int(Job);
+                    start_job_int(Job, State#state.max_history);
                 _ ->
                     ok
                 end,
@@ -105,7 +113,7 @@ handle_call({add_job, Job}, _From, State) ->
 handle_call({remove_job, Id}, _From, State) ->
     case job_by_id(Id) of
         {ok, Job} ->
-            ok = stop_job_int(Job),
+            ok = stop_job_int(Job, State#state.max_history),
             true = remove_job_int(Job),
             {reply, ok, State};
         {error, not_found} ->
@@ -113,7 +121,7 @@ handle_call({remove_job, Id}, _From, State) ->
     end;
 
 handle_call(reschedule, _From, State) ->
-    ok = reschedule(State#state.max_jobs, State#state.max_churn),
+    ok = reschedule(State#state.max_jobs, State#state.max_churn, State#state.max_history),
     {reply, ok, State};
 
 handle_call(_, _From, State) ->
@@ -128,6 +136,10 @@ handle_cast({set_max_churn, MaxChurn}, State) when is_integer(MaxChurn), MaxChur
     couch_log:notice("~p: max_churn set to ~B", [?MODULE, MaxChurn]),
     {noreply, State#state{max_churn = MaxChurn}};
 
+handle_cast({set_max_history, MaxHistory}, State) when is_integer(MaxHistory), MaxHistory > 0 ->
+    couch_log:notice("~p: max_history set to ~B", [?MODULE, MaxHistory]),
+    {noreply, State#state{max_history = MaxHistory}};
+
 handle_cast({set_interval, Interval}, State) when is_integer(Interval), Interval > 0 ->
     couch_log:notice("~p: interval set to ~B", [?MODULE, Interval]),
     {noreply, State#state{interval = Interval}};
@@ -137,7 +149,7 @@ handle_cast(_, State) ->
 
 
 handle_info(reschedule, State) ->
-    ok = reschedule(State#state.max_jobs, State#state.max_churn),
+    ok = reschedule(State#state.max_jobs, State#state.max_churn, State#state.max_history),
     {ok, cancel} = timer:cancel(State#state.timer),
     {ok, Timer} = timer:send_after(State#state.interval, reschedule),
     {noreply, State#state{timer = Timer}};
@@ -153,9 +165,9 @@ handle_info({'DOWN', _Ref, process, Pid, Reason}, State) ->
     couch_log:notice("~p: Job ~p died with reason: ~p",
         [?MODULE, Job0#job.id, Reason]),
     Job1 = update_history(Job0#job{pid = undefined, monitor = undefined},
-        {crashed, Reason}, os:timestamp()),
+        {crashed, Reason}, os:timestamp(), State#state.max_history),
     true = ets:insert(?MODULE, Job1),
-    start_pending_jobs(State#state.max_jobs),
+    start_pending_jobs(State#state.max_jobs, State#state.max_history),
     {noreply, State};
 
 handle_info(_, State) ->
@@ -190,6 +202,10 @@ handle_config_change("replicator", "interval", V, _, Pid) ->
     ok = gen_server:cast(Pid, {set_interval, list_to_integer(V)}),
     {ok, Pid};
 
+handle_config_change("replicator", "max_history", V, _, Pid) ->
+    ok = gen_server:cast(Pid, {set_history, list_to_integer(V)}),
+    {ok, Pid};
+
 handle_config_change(_, _, _, _, Pid) ->
     {ok, Pid}.
 
@@ -206,19 +222,21 @@ handle_config_terminate(Self, _, _) ->
 
 %% private functions
 
-start_jobs(Count) ->
+start_jobs(Count, MaxHistory) ->
     Runnable0 = pending_jobs(),
     Runnable1 = lists:sort(fun oldest_job_first/2, Runnable0),
     Runnable2 = lists:filter(fun not_recently_crashed/1, Runnable1),
     Runnable3 = lists:sublist(Runnable2, Count),
-    lists:foreach(fun start_job_int/1, Runnable3).
+    [start_job_int(Job, MaxHistory) || Job <- Runnable3],
+    ok.
 
 
-stop_jobs(Count) ->
+stop_jobs(Count, MaxHistory) ->
     Running0 = running_jobs(),
     Running1 = lists:sort(fun oldest_job_first/2, Running0),
     Running2 = lists:sublist(Running1, Count),
-    lists:foreach(fun stop_job_int/1, Running2).
+    [stop_job_int(Job, MaxHistory) || Job <- Running2],
+    ok.
 
 
 oldest_job_first(#job{} = A, #job{} = B) ->
@@ -229,15 +247,12 @@ not_recently_crashed(#job{} = Job) ->
     case Job#job.history of
         [] ->
             true;
-        [stopped | _] ->
+        [{stopped, _When} | _] ->
             true;
         _ ->
             EventsBeforeStop = lists:takewhile(
                 fun({Event, _}) -> Event =/= stopped end, Job#job.history),
-            Crashes = lists:filter(
-                fun({{crashed, _Reason}, _When}) -> true; (_) -> false end,
-                EventsBeforeStop
-            ),
+            Crashes = [Crash || {{crashed, _Reason}, _When} = Crash <- EventsBeforeStop],
             case Crashes of
                 [] ->
                     true;
@@ -254,15 +269,15 @@ add_job_int(#job{} = Job) ->
     ets:insert_new(?MODULE, Job).
 
 
-start_job_int(#job{pid = Pid}) when Pid /= undefined ->
+start_job_int(#job{pid = Pid}, _MaxHistory) when Pid /= undefined ->
     ok;
 
-start_job_int(#job{} = Job0) ->
+start_job_int(#job{} = Job0, MaxHistory) ->
     case couch_replicator_scheduler_sup:start_child(Job0#job.rep) of
         {ok, Child} ->
             Ref = monitor(process, Child),
             Job1 = update_history(Job0#job{pid = Child, monitor = Ref},
-                started, os:timestamp()),
+                started, os:timestamp(), MaxHistory),
             true = ets:insert(?MODULE, Job1),
             couch_log:notice("~p: Job ~p started as ~p",
                 [?MODULE, Job1#job.id, Job1#job.pid]);
@@ -272,15 +287,15 @@ start_job_int(#job{} = Job0) ->
     end.
 
 
--spec stop_job_int(#job{}) -> ok | {error, term()}.
-stop_job_int(#job{pid = undefined}) ->
+-spec stop_job_int(#job{}, non_neg_integer()) -> ok | {error, term()}.
+stop_job_int(#job{pid = undefined}, _MaxHistory) ->
     ok;
 
-stop_job_int(#job{} = Job0) ->
+stop_job_int(#job{} = Job0, MaxHistory) ->
     ok = couch_replicator_scheduler_sup:terminate_child(Job0#job.pid),
     demonitor(Job0#job.monitor, [flush]),
     Job1 = update_history(Job0#job{pid = undefined, monitor = undefined},
-        stopped, os:timestamp()),
+        stopped, os:timestamp(), MaxHistory),
     true = ets:insert(?MODULE, Job1),
     couch_log:notice("~p: Job ~p stopped as ~p",
         [?MODULE, Job0#job.id, Job0#job.pid]).
@@ -331,38 +346,38 @@ job_by_id(Id) ->
     end.
 
 
--spec reschedule(MaxJobs :: non_neg_integer(), MaxChurn :: non_neg_integer()) -> ok.
-reschedule(MaxJobs, MaxChurn)
+-spec reschedule(MaxJobs :: non_neg_integer(), MaxChurn :: non_neg_integer(), MaxHistory :: non_neg_integer()) -> ok.
+reschedule(MaxJobs, MaxChurn, MaxHistory)
   when is_integer(MaxJobs), MaxJobs >= 0, is_integer(MaxChurn), MaxChurn > 0 ->
     Running = running_job_count(),
     Pending = pending_job_count(),
-    stop_excess_jobs(MaxJobs, Running),
-    start_pending_jobs(MaxJobs, Running, Pending),
-    rotate_jobs(MaxJobs, MaxChurn, Running, Pending).
+    stop_excess_jobs(MaxJobs, MaxHistory, Running),
+    start_pending_jobs(MaxJobs, MaxHistory, Running, Pending),
+    rotate_jobs(MaxJobs, MaxHistory, MaxChurn, Running, Pending).
 
 
-stop_excess_jobs(Max, Running) when Running > Max ->
-    stop_jobs(Running - Max);
+stop_excess_jobs(MaxJobs, MaxHistory, Running) when Running > MaxJobs ->
+    stop_jobs(Running - MaxJobs, MaxHistory);
 
-stop_excess_jobs(_, _) ->
+stop_excess_jobs(_, _, _) ->
     ok.
 
 
-start_pending_jobs(Max) ->
-    start_pending_jobs(Max, running_job_count(), pending_job_count()).
+start_pending_jobs(MaxJobs, MaxHistory) ->
+    start_pending_jobs(MaxJobs, MaxHistory, running_job_count(), pending_job_count()).
 
 
-start_pending_jobs(Max, Running, Pending) when Running < Max, Pending > 0 ->
-    start_jobs(Max - Running);
+start_pending_jobs(MaxJobs, MaxHistory, Running, Pending) when Running < MaxJobs, Pending > 0 ->
+    start_jobs(MaxJobs - Running, MaxHistory);
 
-start_pending_jobs(_, _, _) ->
+start_pending_jobs(_, _, _, _) ->
     ok.
 
-rotate_jobs(MaxJobs, MaxChurn, Running, Pending) when Running == MaxJobs, Pending > 0 ->
-    stop_jobs(min([Pending, Running, MaxChurn])),
-    start_jobs(min([Pending, Running, MaxChurn]));
+rotate_jobs(MaxJobs, MaxHistory, MaxChurn, Running, Pending) when Running == MaxJobs, Pending > 0 ->
+    stop_jobs(min([Pending, Running, MaxChurn]), MaxHistory),
+    start_jobs(min([Pending, Running, MaxChurn]), MaxHistory);
 
-rotate_jobs(_, _, _, _) ->
+rotate_jobs(_, _, _, _, _) ->
     ok.
 
 
@@ -381,8 +396,8 @@ last_started(#job{} = Job) ->
     end.
 
 
--spec update_history(#job{}, event_type(), erlang:timestamp()) -> #job{}.
-update_history(Job, Type, When) ->
+-spec update_history(#job{}, event_type(), erlang:timestamp(), non_neg_integer()) -> #job{}.
+update_history(Job, Type, When, MaxHistory) ->
     History0 = [{Type, When} | Job#job.history],
-    History1 = lists:sublist(History0, ?MAX_HISTORY),
+    History1 = lists:sublist(History0, MaxHistory),
     Job#job{history = History1}.


### PR DESCRIPTION
This PR adds an exponential backoff for rescheduling erroring jobs. It does this by counting the number of consecutive times which a job has errored in its recorded history (up to a maximum) and using that to calculate the amount of time to wait before rescheduling the job.

This PR also adds a config parameter which is important for exponential backoff: `max_history`. This sets the maximum number of `started`, `stopped`, and `crashed` events which the job will track. Setting a large history will allow the job to be suspended for longer (up to a configurable maximum) but will cause higher memory usage.
