### PR TITLE
Make replicator EUnit tests pass again

### DIFF
--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -19,7 +19,7 @@
 -include("couch_replicator.hrl").
 
 %% public api
--export([start_link/0, add_job/1, remove_job/1]).
+-export([start_link/0, add_job/1, remove_job/1, reschedule/0]).
 
 %% gen_server callbacks
 -export([init/1, terminate/2, code_change/3]).
@@ -69,6 +69,11 @@ remove_job(Id) ->
     gen_server:call(?MODULE, {remove_job, Id}).
 
 
+-spec reschedule() -> ok.
+% Trigger a manual reschedule. Used for testing and/or ops.
+reschedule() ->
+    gen_server:call(?MODULE, reschedule).
+
 %% gen_server functions
 
 init(_) ->
@@ -98,6 +103,10 @@ handle_call({remove_job, Id}, _From, State) ->
         {error, not_found} ->
             {reply, ok, State}
     end;
+
+handle_call(reschedule, _From, State) ->
+    ok = reschedule(State#state.max_jobs, State#state.max_churn),
+    {reply, ok, State};
 
 handle_call(_, _From, State) ->
     {noreply, State}.

--- a/test/couch_replicator_compact_tests.erl
+++ b/test/couch_replicator_compact_tests.erl
@@ -322,6 +322,7 @@ replicate(Source, Target) ->
     ]},
     {ok, Rep} = couch_replicator_utils:parse_rep_doc(RepObject, ?ADMIN_USER),
     ok = couch_replicator_scheduler:add_job(Rep),
+    couch_replicator_scheduler:reschedule(),
     Pid = get_pid(Rep#rep.id),
     {ok, Pid, Rep#rep.id}.
 

--- a/test/couch_replicator_test_helper.erl
+++ b/test/couch_replicator_test_helper.erl
@@ -108,6 +108,7 @@ replicate(Source, Target) ->
 replicate_doc(RepObject) ->
     {ok, Rep} = couch_replicator_utils:parse_rep_doc(RepObject, ?ADMIN_USER),
     ok = couch_replicator_scheduler:add_job(Rep),
+    couch_replicator_scheduler:reschedule(),
     Pid = get_pid(Rep#rep.id),
     MonRef = erlang:monitor(process, Pid),
     receive


### PR DESCRIPTION
After removing rescheduling trigger after adding each job, eunit tests stopped
passing. They rely on a replication starting after a job is added.

Introduce a manual `reschedule/0` function to use it from unit tests and also
for ops purposes (from remsh for example).
