### PR TITLE
Start new jobs immediately

### DIFF
--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -90,6 +90,12 @@ init(_) ->
 handle_call({add_job, Job}, _From, State) ->
     case add_job_int(Job) of
         true ->
+            case running_job_count() of
+                RunningJobs when RunningJobs < State#state.max_jobs ->
+                    start_job_int(Job);
+                _ ->
+                    ok
+                end,
             {reply, ok, State};
         false ->
             {reply, {error, already_added}, State}


### PR DESCRIPTION
Prior to this commit, new jobs would only be restarted when a reschedule
was triggered. This commit changes that behavior such that new jobs will
be started immediately if there is spare capacity.
