### PR TITLE
Cleanup whitespace and gen_server callbacks

### DIFF
--- a/src/couch_multidb_changes.erl
+++ b/src/couch_multidb_changes.erl
@@ -194,11 +194,11 @@ changes_reader(Server, DbName, Since) ->
     {ok, Db} = couch_db:open_int(DbName, [?CTX, sys_db]),
     ChFun = couch_changes:handle_db_changes(
         #changes_args{
-	    include_docs = true,
-	    since = Since,
-	    feed = "normal",
-	    timeout = infinity
-	}, {json_req, null}, Db),
+            include_docs = true,
+            since = Since,
+            feed = "normal",
+            timeout = infinity
+        }, {json_req, null}, Db),
     ChFun({fun ?MODULE:changes_reader_cb/3, {Server, DbName}}).
 
 
@@ -221,10 +221,10 @@ start_event_listener(DbSuffix) ->
 
 handle_db_event(DbName, created, {Server, DbSuffix}) ->
     case DbSuffix =:= couch_db:dbname_suffix(DbName) of
-	true ->
-	    ok = gen_server:call(Server, {created, DbName});
-	_ ->
-	    ok
+        true ->
+            ok = gen_server:call(Server, {created, DbName});
+        _ ->
+            ok
     end,
     {ok, {Server, DbSuffix}};
 
@@ -240,7 +240,7 @@ handle_db_event(DbName, deleted, {Server, DbSuffix}) ->
 handle_db_event(DbName, updated, {Server, DbSuffix}) ->
     case DbSuffix =:= couch_db:dbname_suffix(DbName) of
         true ->
-	    ok = gen_server:cast(Server, {resume_scan, DbName});
+            ok = gen_server:cast(Server, {resume_scan, DbName});
         _ ->
             ok
     end,
@@ -256,16 +256,16 @@ scan_all_dbs(Server, DbSuffix) when is_pid(Server) ->
     Pat = io_lib:format("~s(\\.[0-9]{10,})?.couch$", [DbSuffix]),
     filelib:fold_files(Root, lists:flatten(Pat), true,
         fun(Filename, _) ->
-	    % shamelessly stolen from couch_server.erl
+            % shamelessly stolen from couch_server.erl
             NormFilename = couch_util:normpath(Filename),
             case NormFilename -- NormRoot of
                 [$/ | RelativeFilename] -> ok;
                 RelativeFilename -> ok
             end,
             DbName = ?l2b(filename:rootname(RelativeFilename, ".couch")),
-	    gen_server:cast(Server, {resume_scan, DbName}),
-	    ok
-	end, ok).
+            gen_server:cast(Server, {resume_scan, DbName}),
+            ok
+        end, ok).
 
 
 is_design_doc({Change}) ->
@@ -684,12 +684,14 @@ mock_logs() ->
     meck:expect(couch_log, info, 2, ok),
     meck:expect(couch_log, debug, 2, ok).
 
+
 mock_callback_mod() ->
     meck:new(?MOD, [non_strict]),
     meck:expect(?MOD, db_created, fun(_DbName, Ctx) -> Ctx end),
     meck:expect(?MOD, db_deleted, fun(_DbName, Ctx) -> Ctx end),
     meck:expect(?MOD, db_found, fun(_DbName, Ctx) -> Ctx end),
     meck:expect(?MOD, db_change, fun(_DbName, _Change, Ctx) -> Ctx end).
+
 
 mock_changes_reader_loop({_CbFun, {Server, DbName}}) ->
     receive

--- a/src/couch_multidb_changes.erl
+++ b/src/couch_multidb_changes.erl
@@ -88,6 +88,10 @@ init([DbSuffix, Module, Context, Opts]) ->
     }}.
 
 
+terminate(_Reason, _State) ->
+    ok.
+
+
 handle_call({change, DbName, Change}, _From,
     #state{skip_ddocs=SkipDDocs, mod=Mod, ctx=Ctx} = State) ->
     case {SkipDDocs, is_design_doc(Change)} of
@@ -177,8 +181,6 @@ handle_info({'EXIT', From, Reason}, #state{pids = Pids} = State) ->
             {stop, {unexpected_exit, From, Reason}, State}
     end.
 
-terminate(_Reason, _State) ->
-    ok.
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.

--- a/src/couch_replicator.erl
+++ b/src/couch_replicator.erl
@@ -129,6 +129,3 @@ cancel_replication(RepId, #user_ctx{name = Name, roles = Roles}) ->
             {error, not_found}
         end
      end.
-
-
-

--- a/src/couch_replicator_clustering.erl
+++ b/src/couch_replicator_clustering.erl
@@ -103,6 +103,10 @@ init([]) ->
     }}.
 
 
+terminate(_Reason, _State) ->
+    ok.
+
+
 handle_call(is_stable, _From, State) ->
     {reply, is_stable(State), State}.
 
@@ -142,10 +146,6 @@ handle_info(stability_check, State) ->
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
-
-
-terminate(_Reason, _State) ->
-    ok.
 
 
 %% Internal functions

--- a/src/couch_replicator_clustering.erl
+++ b/src/couch_replicator_clustering.erl
@@ -130,14 +130,15 @@ handle_info(stability_check, State) ->
    timer:cancel(State#state.timer),
    case is_stable(State) of
        true ->
-	   couch_replicator_notifier:notify({cluster, stable}),
+           couch_replicator_notifier:notify({cluster, stable}),
            couch_stats:update_gauge([couch_replicator, cluster_is_stable], 1),
            couch_log:notice("~s : publishing cluster `stable` event", [?MODULE]),
            {noreply, State};
        false ->
-	   Timer = new_timer(interval(State)),
-	   {noreply, State#state{timer = Timer}}
+           Timer = new_timer(interval(State)),
+           {noreply, State#state{timer = Timer}}
    end.
+
 
 code_change(_OldVsn, State, _Extra) ->
     {ok, State}.
@@ -202,5 +203,3 @@ owner_int(DbName, DocId) ->
     Nodes = [N || #shard{node=N} <- mem3:shards(mem3:dbname(DbName), DocId),
                   lists:member(N, Live)],
     hd(mem3_util:rotate_list({DbName, DocId}, lists:sort(Nodes))).
-
-

--- a/src/couch_replicator_db_changes.erl
+++ b/src/couch_replicator_db_changes.erl
@@ -47,7 +47,7 @@ terminate(_Reason, _State) ->
 
 
 handle_call(_Msg, _From, State) ->
-    {noreply, State}.
+    {reply, {error, invalid_call}, State}.
 
 
 handle_cast({cluster, unstable}, State) ->

--- a/src/couch_replicator_db_changes.erl
+++ b/src/couch_replicator_db_changes.erl
@@ -99,5 +99,3 @@ start_link_cluster_event_listener() ->
         end,
     {ok, Pid} = couch_replicator_notifier:start_link(CallbackFun),
     Pid.
-
-

--- a/src/couch_replicator_db_changes.erl
+++ b/src/couch_replicator_db_changes.erl
@@ -42,6 +42,10 @@ init([]) ->
     end.
 
 
+terminate(_Reason, _State) ->
+    ok.
+
+
 handle_call(_Msg, _From, State) ->
     {noreply, State}.
 
@@ -55,10 +59,6 @@ handle_cast({cluster, stable}, State) ->
 
 handle_info(_Msg, State) ->
     {noreply, State}.
-
-
-terminate(_Reason, _State) ->
-    ok.
 
 
 code_change(_OldVsn, State, _Extra) ->

--- a/src/couch_replicator_docs.erl
+++ b/src/couch_replicator_docs.erl
@@ -95,10 +95,10 @@ ensure_rep_db_exists() ->
 -spec ensure_rep_ddoc_exists(binary()) -> ok.
 ensure_rep_ddoc_exists(RepDb) ->
     case mem3:belongs(RepDb, ?REP_DESIGN_DOC) of
-	true ->
-	    ensure_rep_ddoc_exists(RepDb, ?REP_DESIGN_DOC);
-	false ->
-	    ok
+        true ->
+            ensure_rep_ddoc_exists(RepDb, ?REP_DESIGN_DOC);
+        false ->
+            ok
     end.
 
 -spec ensure_rep_ddoc_exists(binary(), binary()) -> ok.
@@ -571,5 +571,3 @@ check_options_fail_values_test() ->
         check_options([{doc_ids, x}, {selector, y}, {filter, z}])).
 
 -endif.
-
-


### PR DESCRIPTION
Whitespace fixes:
- Indentation
- Remove tabs
- Remove trailing whitespace

gen_server:
- Try to maintain callback order:
  - init
  - terminate
  - handle_call
  - handle_cast
  - handle_info
  - code_change
- Be nice on receipt of errant call, reply with error.
