### PR TITLE
Checkpoint when jobs are unscheduled

### DIFF
--- a/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator_scheduler_job.erl
@@ -406,9 +406,19 @@ terminate(normal, #rep_state{rep_details = #rep{id = RepId} = Rep,
     doc_update_completed(Rep, rep_stats(State));
 
 terminate(shutdown, #rep_state{rep_details = #rep{id = RepId}} = State) ->
-    % cancelled replication throught ?MODULE:cancel_replication/1
-    couch_replicator_notifier:notify({error, RepId, <<"cancelled">>}),
-    terminate_cleanup(State);
+    % Replication stopped via _scheduler_sup:terminate_child/1, which can be
+    % occur during regular scheduler operation or when job is removed from
+    % the scheduler.
+    State1 = case do_last_checkpoint(State) of
+        {stop, normal, NewState} ->
+            NewState;
+        {stop, Error, NewState} ->
+            LogMsg = "~p : Failed last checkpoint. Job: ~p Error: ~p",
+            couch_log:error(LogMsg, [?MODULE, RepId, Error]),
+            NewState
+    end,
+    couch_replicator_notifier:notify({stopped, RepId, <<"stopped">>}),
+    terminate_cleanup(State1);
 
 terminate(shutdown, {error, Class, Error, Stack, InitArgs}) ->
     #rep{id=RepId} = InitArgs,


### PR DESCRIPTION
But check if hasn't just checkpointed, where "just" is last 5 seconds.

Uses a simpler approach -- handles it in `terminate(shutdown, ..)` clause.

`terminate(shutdown, ...)` is called as a result of supervisor:terminate_child,
which is called when jobs are stopped. Updated notification event and comment to
reflect that. When user "cancels" a replication there is no direct call to
job supervisor, it is a remove_job call to job scheduler, which will then stop
the job if it is running. So {error, <<"canceled">>} didn't fit the event
properly.

Using terminate has a few benefits:
- If it takes too long supervisor does the right thing and kills the process
  and cleans up.
- If it throws an exception supervisor will also clean up.
- Keeps the job scheduler simple -- manages jobs via superviser and doesn't have
  to handle either blocked gen_server calls (timeouts), or send casts but then
  decide how long to wait before calling terminate_child for a final cleanup.
