### PR TITLE
Add view to query replicator documents in terminal states

### DIFF
--- a/src/couch_replicator_docs.erl
+++ b/src/couch_replicator_docs.erl
@@ -109,10 +109,17 @@ ensure_rep_ddoc_exists(RepDb, DDocId) ->
         {ok, _Doc} ->
             ok;
         _ ->
+            TerminalViewEJson = {[
+                {<<"map">>, ?REP_DB_TERMINAL_STATE_VIEW_MAP_FUN},
+                {<<"reduce">>, <<"_count">>}
+            ]},
             DDoc = couch_doc:from_json_obj({[
                 {<<"_id">>, DDocId},
                 {<<"language">>, <<"javascript">>},
-                {<<"validate_doc_update">>, ?REP_DB_DOC_VALIDATE_FUN}
+                {<<"validate_doc_update">>, ?REP_DB_DOC_VALIDATE_FUN},
+                {<<"views">>, {[
+                    {<<"terminal_states">>, TerminalViewEJson}
+                ]}}
             ]}),
             try
                 {ok, _} = save_rep_doc(RepDb, DDoc),

--- a/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator_js_functions.hrl
@@ -168,3 +168,12 @@
         }
     }
 ">>).
+
+
+-define(REP_DB_TERMINAL_STATE_VIEW_MAP_FUN, <<"
+    function(doc) {
+        if (typeof doc._replication_state === 'string') {
+            emit(doc._replication_state, null);
+        }
+    }
+">>).


### PR DESCRIPTION
Currently there are two terminal states - `completed` and `failed`.

These states are reached when scheduler decides it will no longer pay
attention to the document. Either because it represents a completed replication,
or an unrecoverable failure occured, such as specifying an invalid replication
parameter. In case of failure, user is expected to fix the cause of the failure
and then recreate the document.

Since scheduler forgets about these documents, the only way to inspect is to
look in the database. So create a view to help users perfom that query.

The view is `_replicator/_design/_replicator/_view/terminal_states`

Example of usage:

```
http http://adm:pass@localhost:15984/_replicator/_design/_replicator/_view/terminal_states
{
    "offset": 0,
    "rows": [
        {
            "id": "rdyno_0001_0001",
            "key": "completed",
            "value": null
        },
        {
            "id": "rdyno_0001_0002",
            "key": "completed",
            "value": null
        },
        {
            "id": "badrep",
            "key": "failed",
            "value": null
        }
    ],
    "total_rows": 3
}
```
