### PR TITLE
Add docs/0 function to doc processor & streaming document info APIs to replicator

### DIFF
--- a/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator_js_functions.hrl
@@ -173,7 +173,7 @@
 -define(REP_DB_TERMINAL_STATE_VIEW_MAP_FUN, <<"
     function(doc) {
         if (typeof doc._replication_state === 'string') {
-            emit(doc._replication_state, null);
+            emit(doc._replication_state, doc._replication_state_reason);
         }
     }
 ">>).


### PR DESCRIPTION
`docs/0` function as well as API functions from `replicator` modules are used to introspect the state of replication documents.  

`docs/0` produces local (from current node) result showing active (i.e. non-complete and non-failed) documents.

`stream_active_docs_info` and `stream_terminal_docs_info` produce cluster wide stream of ejson objects with info about replication documents. These results are cluster wide. They are have instead of chttpd or Cloudant specific plugin because they involved internal details of how replicator arranges its views / databases /ets tables.

This pr also updates the default replicator db view to include reason for failure. In all likelihood if user sees a failed document, the next thing they'd do is query it so see why it failed. So just include it in the view.
