### PR TITLE
Address Timeout Issues for 429

### DIFF
--- a/src/couch_replicator_changes_reader.erl
+++ b/src/couch_replicator_changes_reader.erl
@@ -52,7 +52,10 @@ read_changes(Parent, StartSeq, Db, ChangesQueue, Options, Ts) ->
         throw:recurse ->
             LS = get(last_seq),
             read_changes(Parent, LS, Db, ChangesQueue, Options, Ts+1);
-        exit:{http_request_failed, _, _, _} = Error ->
+        throw:retry_no_limit ->
+            LS = get(last_seq),
+            read_changes(Parent, LS, Db, ChangesQueue, Options, Ts);
+        throw:{retry_limit, Error} ->
         couch_stats:increment_counter(
             [couch_replicator, changes_read_failures]
         ),

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -277,12 +277,12 @@ backoff(Worker, #httpdb{backoff = Backoff} = HttpDb, Params) ->
     NewBackoff = erlang:min(Backoff2, ?MAX_BACKOFF_WAIT),
     NewHttpDb = HttpDb#httpdb{backoff = NewBackoff},
     case Backoff2 of
-        W0 when W0 >= ?MAX_BACKOFF_LOG_THRESHOLD -> % Past 8 min, we log retries
+        W0 when W0 > ?MAX_BACKOFF_WAIT ->
+            report_error(Worker, HttpDb, Params, {error,
+                "Long 429-induced Retry Time Out"});
+        W1 when W1 >= ?MAX_BACKOFF_LOG_THRESHOLD -> % Past 8 min, we log retries
             log_retry_error(Params, HttpDb, Backoff2, "429 Retry"),
             throw({retry, NewHttpDb, Params});
-        W1 when W1 > ?MAX_BACKOFF_WAIT ->
-            report_error(Worker, HttpDb, Params, {error,
-                "429 Retry Timeout"});
         _ ->
             throw({retry, NewHttpDb, Params})
     end.

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -180,6 +180,9 @@ process_stream_response(ReqId, Worker, HttpDb, Params, Callback) ->
                 Ret = Callback(Ok, Headers, StreamDataFun),
                 Ret
             catch
+                throw:{maybe_retry_req, connection_closed} ->
+                    maybe_retry({connection_closed, mid_stream},
+                        Worker, HttpDb, Params);
                 throw:{maybe_retry_req, Err} ->
                     maybe_retry(Err, Worker, HttpDb, Params)
             end;


### PR DESCRIPTION
There are two timeout issues found with testing against a ccm enabled cluster.

1) We weren't actually timing out with the MAX_BACKOFF_WAIT because the clause order was incorrect. I switched clause to ensure now that we actually report an error when our backoff hits MAX_BACKOFF_WAIT.

2) Haproxy has a timeout of 150000 ms for idling clients. During a changes feed, when our backoff is large enough, it will trigger the timeout and haproxy will kill the connection. This was confirmed when we upped the timeout on haproxy to one hour and no longer saw connections being killed. 

I considered various ways to address this issue, and I think throwing a special case error 

```
{connection_closed, mid_stream}
```

is the most sensible approach. 

When we encounter a connection_closed error during the middle of a stream, it could not only just be a timeout, but also some random network error. We should just perform a simple retry because:

a) Timeout - If it's some timeout problem, we know that we were in the middle of a stream, and we at least received some changes back. The retry will try to establish a connection again and if it hits a 429, then it will simply restart(25 ms wait) the backoff procedure again, without starting a stream. If the retry succeeds, then a new connection will established and a new stream will begin again. Obviously, at some point during the stream we'll timeout again due to haproxy, but it will make progress. This seems like a limitation we must live with. 

b) Actual Network Error - When it's an actual network error, the retry attempt won't go through the same code path again because a new connection cannot be establish. The _changes request won't be in mid stream. The request will simply fail in the initial connection attempt and go through the standard 10 retry path and fail normally. This way, the replication doesn't get stuck when an actual network error occurs.
