### PR TITLE
Prevent ibrowse connections from being cleaned up too soon

### DIFF
--- a/src/couch_replicator_connection.erl
+++ b/src/couch_replicator_connection.erl
@@ -50,6 +50,7 @@ init([]) ->
     ok = config:listen_for_changes(?MODULE, self()),
     Interval = config:get_integer("replicator", "connection_close_interval", ?DEFAULT_CLOSE_INTERVAL),
     {ok, Timer} = timer:send_after(Interval, close_idle_connections),
+    ibrowse:add_config([{inactivity_timeout, Interval}]),
     {ok, #state{close_interval=Interval, timer=Timer}}.
 
 
@@ -117,6 +118,7 @@ handle_cast({relinquish, WorkerPid}, State) ->
 handle_cast({connection_close_interval, V}, State) ->
     {ok, cancel} = timer:cancel(State#state.timer),
     {ok, NewTimer} = timer:send_after(V, close_idle_connections),
+    ibrowse:add_config([{inactivity_timeout, V}]),
     {noreply, State#state{close_interval=V, timer=NewTimer}}.
 
 


### PR DESCRIPTION
After a request finishes, ibrowse will reset the state of the request and set
an idle timer. If connection is not reused in that time, it will be cleaned up
(process exits with `normal`).

In the scheduler pool we specify a custom idle connection timeout implied by
the `connection_close_interval` config setting, so make sure to set ibrowse's
idle timeout to match that, otherwise we are not getting the intended reuse
out of the pool.
