### PR TITLE
63012 scalability fixes

### DIFF
--- a/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator_doc_processor.erl
@@ -31,7 +31,7 @@
     get_json_value/3
 ]).
 
--define(ERROR_MAX_BACKOFF_EXPONENT, 17).  % ~ 1 day on average
+-define(ERROR_MAX_BACKOFF_EXPONENT, 12).  % ~ 1 day on average
 -define(TS_DAY_SEC, 86400).
 
 -type filter_type() ::  nil | view | user | docids | mango.
@@ -295,7 +295,7 @@ update_docs_row(#rdoc{rid = OldRepId, filter = user} = Row, RepId) ->
 -spec error_backoff(non_neg_integer()) -> seconds().
 error_backoff(ErrCnt) ->
     Exp = min(ErrCnt, ?ERROR_MAX_BACKOFF_EXPONENT),
-    5 + random:uniform(1 bsl Exp).
+    random:uniform(64 bsl Exp).
 
 
 -spec filter_backoff() -> seconds().

--- a/src/couch_replicator_doc_processor_worker.erl
+++ b/src/couch_replicator_doc_processor_worker.erl
@@ -57,8 +57,9 @@ worker_fun(Id, Rep, WaitSec) ->
         erlang:demonitor(Ref, [flush]),
         exit(Pid, kill),
         {DbName, DocId} = Id,
+        TimeoutSec = round(?WORKER_TIMEOUT_MSEC / 1000),
         Msg = io_lib:format("Replication for db ~p doc ~p failed to start due "
-            "to timeout after ~B seconds", [DbName, DocId, ?WORKER_TIMEOUT_MSEC/1000]),
+            "to timeout after ~B seconds", [DbName, DocId, TimeoutSec]),
         Result = {temporary_error, couch_util:to_binary(Msg)},
         exit(#doc_worker_result{id = Id, result = Result})
     end.

--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -77,18 +77,18 @@ add_job(#rep{} = Rep) when Rep#rep.id /= undefined ->
         id = Rep#rep.id,
         rep = Rep,
         history = [{added, os:timestamp()}]},
-    gen_server:call(?MODULE, {add_job, Job}).
+    gen_server:call(?MODULE, {add_job, Job}, infinity).
 
 
 -spec remove_job(job_id()) -> ok.
 remove_job(Id) ->
-    gen_server:call(?MODULE, {remove_job, Id}).
+    gen_server:call(?MODULE, {remove_job, Id}, infinity).
 
 
 -spec reschedule() -> ok.
 % Trigger a manual reschedule. Used for testing and/or ops.
 reschedule() ->
-    gen_server:call(?MODULE, reschedule).
+    gen_server:call(?MODULE, reschedule, infinity).
 
 
 -spec rep_state(rep_id()) -> #rep{} | nil.


### PR DESCRIPTION
- Increase initial error backoff in doc processor
- Do not time-out scheduler's gen-server calls
- Fix error in io_lib_format line.
- Make add_job return quicker, by avoiding an expensive `O(n)` select call.

![1m_success](https://cloud.githubusercontent.com/assets/211822/17454200/8e559fe2-5b5b-11e6-9b1a-4dcd9754f107.png)

(Red line is the node which contains this patch. It reaches 300K+ jobs while others fail).
