### PR TITLE
63012 merge latest master

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -389,7 +389,7 @@ changes_reader_cb({change, Change, _}, _, {Server, DbName, Epoch}) ->
     end,
     {Server, DbName, Epoch};
 changes_reader_cb({stop, EndSeq}, _, {Server, DbName, Epoch}) ->
-    Msg = {rep_db_checkpoint, DbName, EndSeq},
+    Msg = {rep_db_checkpoint, DbName, EndSeq, Epoch},
     ok = gen_server:call(Server, Msg, infinity),
     {Server, DbName, Epoch};
 changes_reader_cb(_, _, Acc) ->

--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -388,7 +388,7 @@ changes_reader_cb({change, Change, _}, _, {Server, DbName, Epoch}) ->
             ok
     end,
     {Server, DbName, Epoch};
-changes_reader_cb({stop, EndSeq, _Pending}, _, {Server, DbName, Epoch}) ->
+changes_reader_cb({stop, EndSeq}, _, {Server, DbName, Epoch}) ->
     Msg = {rep_db_checkpoint, DbName, EndSeq},
     ok = gen_server:call(Server, Msg, infinity),
     {Server, DbName, Epoch};


### PR DESCRIPTION
Merge changes from master.
- Changes to replicator manager were resolved to be ignored. There is no more replicator manager.
- Validate boolean parameters auto-merged to _utils.erl, but it was wrong and had to be moved to _docs.erl
- Updated config listeners to conform to latest master config listener behaviour.
