### PR TITLE
Make crash errors more user friendly

### DIFF
--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -753,8 +753,8 @@ crash_reason_json({_CrashType, Info}) when is_binary(Info) ->
     Info;
 crash_reason_json(Reason) when is_binary(Reason) ->
     Reason;
-crash_reason_json(_) ->
-    <<"unknown">>.
+crash_reason_json(Error) ->
+    couch_replicator_utils:rep_error_to_binary(Error).
 
 
 -spec is_continuous(#job{}) -> boolean().

--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -73,6 +73,8 @@ rep_error_to_binary(Error) ->
     couch_util:to_binary(error_reason(Error)).
 
 
+error_reason({shutdown, Error}) ->
+    error_reason(Error);
 error_reason({error, {Error, Reason}})
   when is_atom(Error), is_binary(Reason) ->
     io_lib:format("~s: ~s", [Error, Reason]);


### PR DESCRIPTION
- Expose errors previously hidden behind the "unknown" label. End users might
  not always descipher the error, but having a specific error might lead to
  getting help faster from other sources.
- Expose errors during replication start phase. Previously hidden by "shutdown"
  reason. Startup is an area which is expected to generate errors more frequently,
  as this is where source or target db is opend the first time. There was already
  a mechanism to log and notify gen_event listeners with a friendly error message,
  however scheduler only looked at the exit reason which was always shutdown.

During source failure for example `_scheduler/jobs` output would look like:

```
"history": [
            {
                "reason": "shutdown",
                "timestamp": "2016-10-10T03-59-47.696599Z",
                "type": "crashed"
            },
...
```

After this commit it should look like:

```
"history": [
            {
                "reason": "db_not_found: could not open http://adm:*****@localhost:15984/cdyno-0000001/",
                "timestamp": "2016-10-10T04-41-47.75992Z",
                "type": "crashed"
            },
...
```
