### PR TITLE
63012 scheduler better docs

### DIFF
--- a/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator_js_functions.hrl
@@ -180,8 +180,11 @@
 
 -define(REP_DB_TERMINAL_STATE_VIEW_MAP_FUN, <<"
     function(doc) {
-        if (typeof doc._replication_state === 'string') {
-            emit(doc._replication_state, doc._replication_state_reason);
+        state = doc._replication_state;
+        if (state === 'failed') {
+            emit('failed', doc._replication_state_reason);
+        } else if (state === 'completed') {
+            emit('completed', doc._replication_stats);
         }
     }
 ">>).


### PR DESCRIPTION
 Update couch_replicator provide a better docs summary

Improved state filtering. couch_replicator:docs can take a list of state atoms
and return only jobs which are in those states. An empty states list serves as
a wildcard.

Replications which are scheduled return a summary with their scheduling status.
Previously they returned only their state as seen from the document processor
compoenent, thus forcing an end-user to understand that there are two separate
sub-systems involved with their own error states and behavior.

Document results are provided in somewhat stable sorted order, suitable for
streaming and pagination via limit and offset. Doc processor ets tables is
sorted by document id and terminal states documents are sorted by their state.
Even though sorting criteria is different is stays relatively consistent between
calls.

Also to support sorted streaming of data, switched rpc:multicall to rpc:calls
with a sorted list of nodes.
