### PR TITLE
Let _admin role bypass VDU

### DIFF
--- a/src/couch_replicator_docs.erl
+++ b/src/couch_replicator_docs.erl
@@ -375,7 +375,10 @@ parse_rep_db(<<"http://", _/binary>> = Url, ProxyParams, Options) ->
 parse_rep_db(<<"https://", _/binary>> = Url, ProxyParams, Options) ->
     parse_rep_db({[{<<"url">>, Url}]}, ProxyParams, Options);
 parse_rep_db(<<DbName/binary>>, _ProxyParams, _Options) ->
-    DbName.
+    DbName;
+parse_rep_db(undefined, _ProxyParams, _Options) ->
+    throw({error, <<"Missing replicator database">>}).
+
 
 -spec maybe_add_trailing_slash(binary() | list()) -> list().
 maybe_add_trailing_slash(Url) when is_binary(Url) ->

--- a/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator_js_functions.hrl
@@ -53,6 +53,14 @@
         var isReplicator = (userCtx.roles.indexOf('_replicator') >= 0);
         var isAdmin = (userCtx.roles.indexOf('_admin') >= 0);
 
+        if (newDoc._replication_state === 'failed') {
+            // Skip validation in case when we update the document with the
+            // failed state. In this case it might be malformed. However,
+            // replicator will not pay attention to failed documents so this
+            // is safe.
+            return;
+        }
+
         if (oldDoc && !newDoc._deleted && !isReplicator &&
             (oldDoc._replication_state === 'triggered')) {
             reportError('Only the replicator can edit replication documents ' +


### PR DESCRIPTION
This is necessary in the case where an upgrade happens and replicator had
invalid document in them. Replicator would read it and then try to update it
with a failed state. However update will fail because the VDU might prevent it.
