### PR TITLE
Improve replicator design doc update logic

### DIFF
--- a/src/couch_replicator_filters.erl
+++ b/src/couch_replicator_filters.erl
@@ -13,6 +13,7 @@
 -module(couch_replicator_filters).
 
 -export([parse/1, fetch/4, view_type/2]).
+-export([ejsort/1]).
 
 -include_lib("couch/include/couch_db.hrl").
 


### PR DESCRIPTION
Previously only VDU function was compared so that terminal_states was not
updated if VDU function didni't change. Even when it did change only the
VDU function code was updated but not the view.

Since replicator controls the whole _design/_replicator document, just compare
the whole document for change. This it is also more future proof. Any changes
will be updated.
