### PR TITLE
63012 scheduler remove doc before update

### DIFF
--- a/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator_js_functions.hrl
@@ -61,12 +61,6 @@
             return;
         }
 
-        if (oldDoc && !newDoc._deleted && !isReplicator &&
-            (oldDoc._replication_state === 'triggered')) {
-            reportError('Only the replicator can edit replication documents ' +
-                'that are in the triggered state.');
-        }
-
         if (!newDoc._deleted) {
             validateEndpoint(newDoc.source, 'source');
             validateEndpoint(newDoc.target, 'target');


### PR DESCRIPTION
 Cleanup previous replications during update.

In previous version of replicator replication documents were not updatable by
the user after they become "triggered". That ensured that each update to a
replication job necessarily happened via a document deletion first. Then first
update to the document was the creation of a replication job.

That design constraint was erroneously ported forward but is inconsistent with
current replicator behavior, as triggered state is not persisted to the
document anymore. The effect of this is on replication document updates a new
replication job is started by older replication job still stays running.

The fix is to allow document updates, not force user to do deletions first, and
before each update ensure to clean up any replication jobs.

Also clean up un-used VDU check for `triggered` state.
