### PR TITLE
Fix _scheduler/docs filtering for users

### DIFF
--- a/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator_doc_processor.erl
@@ -401,7 +401,7 @@ ejson_doc(#rdoc{state = scheduled} = RDoc, HealthThreshold) ->
         [{_, _} | _] ->
             {[
                 {doc_id, DocId},
-                {database, mem3:dbname(DbName)},
+                {database, DbName},
                 {id, ejson_rep_id(RepId)},
                 {node, node()} | JobProps
             ]}


### PR DESCRIPTION
Previously docs endpoint returned the mem3:dbname/1 version of the database to
make it look more familiar to end users (instead of the shard path). However,
during tasks filtering couch_util:customer_name/1 looks at the `database` field
expecting it be a full shard path in order to extract the user.
