### PR TITLE
Canceling a transient replication via a "replication_id" works again

### DIFF
--- a/src/couch_replicator_docs.erl
+++ b/src/couch_replicator_docs.erl
@@ -194,7 +194,12 @@ parse_rep_doc_without_id(RepDoc) ->
 -spec parse_rep_doc({[_]}, #user_ctx{}) -> {ok, #rep{}}.
 parse_rep_doc(Doc, UserCtx) ->
     {ok, Rep} = parse_rep_doc_without_id(Doc, UserCtx),
-    {ok, update_rep_id(Rep)}.
+    case get_value(cancel, Rep#rep.options, false) of
+        true ->
+            {ok, Rep};
+        false ->
+            {ok, update_rep_id(Rep)}
+    end.
 
 
 -spec parse_rep_doc_without_id({[_]}, #user_ctx{}) -> {ok, #rep{}}.


### PR DESCRIPTION
Canceling a transient replication by POST-ing to _replicate was failing because
it was assumed request body had to always be well-formed (with source, target,
...).

However it is valid to cancel a replication with a body which has just
`"cancel": true` and either `replication_id`, `id` or `_local_id` fields.

Example:

Creating a transient continuous replication

```
http --auth=adm:pass :15984/_replicate \
  source='http://adm:pass@localhost:15984/s' \
  target='http://adm:pass@localhost:15984/r' \
  create_target:='true' \
  continuous:='true'
{
    "_local_id": "14ed9e9f8411232bdcd2387a8f578806+continuous+create_target",
    "ok": true
}
```

Canceling

```
http --auth=adm:pass :15984/_replicate \
  cancel:='true' \
  replication_id='14ed9e9f8411232bdcd2387a8f578806+continuous+create_target'
{
    "_local_id": "14ed9e9f8411232bdcd2387a8f578806+continuous+create_target",
    "ok": true
}
```

Log shows:

```
Canceling replication '14ed9e9f8411232bdcd2387a8f578806+continuous+create_target'
```
