### PR TITLE
When adding job, first call maybe_delete existent job then call add

### DIFF
--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -175,18 +175,13 @@ init(_) ->
 
 
 handle_call({add_job, Job}, _From, State) ->
-    case add_job_int(Job) of
-        true ->
-            ok = maybe_remove_job_int(Job#job.id, State),
-            ok = maybe_start_newly_added_job(Job, State),
-            couch_stats:increment_counter([couch_replicator, jobs, adds]),
-            TotalJobs = ets:info(?MODULE, size),
-            couch_stats:update_gauge([couch_replicator, jobs, total], TotalJobs),
-            {reply, ok, State};
-        false ->
-            couch_stats:increment_counter([couch_replicator, jobs, duplicate_adds]),
-            {reply, {error, already_added}, State}
-    end;
+    ok = maybe_remove_job_int(Job#job.id, State),
+    true = add_job_int(Job),
+    ok = maybe_start_newly_added_job(Job, State),
+    couch_stats:increment_counter([couch_replicator, jobs, adds]),
+    TotalJobs = ets:info(?MODULE, size),
+    couch_stats:update_gauge([couch_replicator, jobs, total], TotalJobs),
+    {reply, ok, State};
 
 handle_call({remove_job, Id}, _From, State) ->
     ok = maybe_remove_job_int(Id, State),


### PR DESCRIPTION
Previously job was added, then removed. However surprisingly sometimes
it still worked because job was also started (if less then max_job were
running), and during start job record is inserted in the ets table.
However, as soon as max_jobs limit was reached jobs were not added to
the job ets table anymore.
