### PR TITLE
Fix _scheduler/docs filtering by database name.

### DIFF
--- a/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator_doc_processor.erl
@@ -437,7 +437,7 @@ ejson_doc(#rdoc{state = RepState} = RDoc, _HealthThreshold) ->
     } = RDoc,
     {[
         {doc_id, DocId},
-        {database, mem3:dbname(DbName)},
+        {database, DbName},
         {id, ejson_rep_id(RepId)},
         {state, RepState},
         {info, ejson_state_info(StateInfo)},


### PR DESCRIPTION
mem3:dbname() transformation needs to be done in showroom endpoint, doing it
too early prevents filtering by user in showroom and so docs ends up "missing"
in the query output.
