### PR TITLE
Add start_time and last_updated fields to _scheduler/ endpoints output 

### DIFF
--- a/src/couch_replicator.hrl
+++ b/src/couch_replicator.hrl
@@ -21,7 +21,8 @@
     type = db :: atom() | '_',
     view = nil :: any() | '_',
     doc_id :: any() | '_',
-    db_name = null :: null | binary() | '_'
+    db_name = null :: null | binary() | '_',
+    start_time :: erlang:timestamp() | '_'
 }).
 
 -type rep_id() :: {string(), string()}.

--- a/src/couch_replicator_doc_processor_worker.erl
+++ b/src/couch_replicator_doc_processor_worker.erl
@@ -78,7 +78,8 @@ maybe_start_replication(Id, RepWithoutId) ->
         {temporary_error, Reason};
     {permanent_failure, Reason} ->
         {DbName, DocId} = Id,
-        couch_replicator_docs:update_failed(DbName, DocId, Reason),
+        StartTime = Rep#rep.start_time,
+        couch_replicator_docs:update_failed(DbName, DocId, Reason, StartTime),
         {permanent_failure, Reason}
     end.
 
@@ -199,7 +200,7 @@ setup() ->
     meck:expect(couch_replicator_scheduler, add_job, 1, ok),
     meck:expect(config, get, fun(_, _, Default) -> Default end),
     meck:expect(couch_server, get_uuid, 0, this_is_snek),
-    meck:expect(couch_replicator_docs, update_failed, 3, ok),
+    meck:expect(couch_replicator_docs, update_failed, 4, ok),
     meck:expect(couch_replicator_scheduler, rep_state, 1, nil),
     ok.
 

--- a/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator_js_functions.hrl
@@ -176,9 +176,15 @@
     function(doc) {
         state = doc._replication_state;
         if (state === 'failed') {
-            emit('failed', doc._replication_state_reason);
+            start_time = doc._replication_start_time;
+            last_updated = doc._replication_state_time;
+            state_reason = doc._replication_state_reason;
+            emit('failed', [start_time, last_updated, state_reason]);
         } else if (state === 'completed') {
-            emit('completed', doc._replication_stats);
+            start_time = doc._replication_start_time;
+            last_updated = doc._replication_state_time;
+            stats = doc._replication_stats;
+            emit('completed', [start_time, last_updated, stats]);
         }
     }
 ">>).

--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -20,6 +20,7 @@
 -export([rep_error_to_binary/1]).
 -export([get_json_value/2, get_json_value/3]).
 -export([pp_rep_id/1]).
+-export([iso8601/1]).
 
 -export([handle_db_event/3]).
 
@@ -135,3 +136,10 @@ sum_stats(S1, S2) ->
 
 parse_rep_doc(Props, UserCtx) ->
     couch_replicator_docs:parse_rep_doc(Props, UserCtx).
+
+
+-spec iso8601(erlang:timestamp()) -> binary().
+iso8601({_Mega, _Sec, _Micro} = Timestamp) ->
+    {{Y, Mon, D}, {H, Min, S}} = calendar:now_to_universal_time(Timestamp),
+    Format = "~B-~2..0B-~2..0BT~2..0B-~2..0B-~2..0BZ",
+    iolist_to_binary(io_lib:format(Format, [Y, Mon, D, H, Min, S])).


### PR DESCRIPTION
Also for consistency add _replication_start_time field to completed and failed
replication document updates.

`start_time` is defined as the time since the replication first was noticed by
the replicator. For a document-based replication it is when the document update
event reached couch replicator and the replication record was parsed from it.
For a _replicate replication it is the time when the POST request body was
parsed.

`last_updated` is time of last state update.