### PR TITLE
Implement Compatibility Mode

### DIFF
--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -996,13 +996,13 @@ header_value(Key, Headers, Default) ->
 % comparisons. This means remove things like pids and also sort options / props.
 normalize_db(#httpdb{} = HttpDb) ->
     #httpdb{
-       url = HttpDb#httpdb.url,
-       oauth = HttpDb#httpdb.oauth,
-       headers = lists:keysort(1, HttpDb#httpdb.headers),
-       timeout = HttpDb#httpdb.timeout,
-       ibrowse_options = lists:keysort(1, HttpDb#httpdb.ibrowse_options),
-       retries = HttpDb#httpdb.retries,
-       http_connections = HttpDb#httpdb.http_connections
+        url = HttpDb#httpdb.url,
+        oauth = HttpDb#httpdb.oauth,
+        headers = lists:keysort(1, HttpDb#httpdb.headers),
+        timeout = HttpDb#httpdb.timeout,
+        ibrowse_options = lists:keysort(1, HttpDb#httpdb.ibrowse_options),
+        retries = HttpDb#httpdb.retries,
+        http_connections = HttpDb#httpdb.http_connections
     };
 
 normalize_db(<<DbName/binary>>) ->
@@ -1016,13 +1016,13 @@ normalize_db(<<DbName/binary>>) ->
 
 normalize_http_db_test() ->
     HttpDb =  #httpdb{
-       url = "http://host/db",
-       oauth = #oauth{},
-       headers = [{"k2","v2"}, {"k1","v1"}],
-       timeout = 30000,
-       ibrowse_options = [{k2, v2}, {k1, v1}],
-       retries = 10,
-       http_connections = 20
+        url = "http://host/db",
+        oauth = #oauth{},
+        headers = [{"k2","v2"}, {"k1","v1"}],
+        timeout = 30000,
+        ibrowse_options = [{k2, v2}, {k1, v1}],
+        retries = 10,
+        http_connections = 20
     },
     Expected = HttpDb#httpdb{
         headers = [{"k1","v1"}, {"k2","v2"}],

--- a/src/couch_replicator_api_wrap.erl
+++ b/src/couch_replicator_api_wrap.erl
@@ -38,7 +38,8 @@
     open_doc/3,
     open_doc_revs/6,
     changes_since/5,
-    db_uri/1
+    db_uri/1,
+    normalize_db/1
     ]).
 
 -import(couch_replicator_httpc, [
@@ -989,3 +990,46 @@ header_value(Key, Headers, Default) ->
         _ ->
             Default
     end.
+
+
+% Normalize an #httpdb{} or #db{} record such that it can be used for
+% comparisons. This means remove things like pids and also sort options / props.
+normalize_db(#httpdb{} = HttpDb) ->
+    #httpdb{
+       url = HttpDb#httpdb.url,
+       oauth = HttpDb#httpdb.oauth,
+       headers = lists:keysort(1, HttpDb#httpdb.headers),
+       timeout = HttpDb#httpdb.timeout,
+       ibrowse_options = lists:keysort(1, HttpDb#httpdb.ibrowse_options),
+       retries = HttpDb#httpdb.retries,
+       http_connections = HttpDb#httpdb.http_connections
+    };
+
+normalize_db(<<DbName/binary>>) ->
+    DbName.
+
+
+-ifdef(TEST).
+
+-include_lib("eunit/include/eunit.hrl").
+
+
+normalize_http_db_test() ->
+    HttpDb =  #httpdb{
+       url = "http://host/db",
+       oauth = #oauth{},
+       headers = [{"k2","v2"}, {"k1","v1"}],
+       timeout = 30000,
+       ibrowse_options = [{k2, v2}, {k1, v1}],
+       retries = 10,
+       http_connections = 20
+    },
+    Expected = HttpDb#httpdb{
+        headers = [{"k1","v1"}, {"k2","v2"}],
+        ibrowse_options = [{k1, v1}, {k2, v2}]
+    },
+    ?assertEqual(Expected, normalize_db(HttpDb)),
+    ?assertEqual(<<"local">>, normalize_db(<<"local">>)).
+
+
+-endif.

--- a/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator_doc_processor.erl
@@ -217,7 +217,7 @@ code_change(_OldVsn, State, _Extra) ->
 % same document.
 -spec updated_doc(db_doc_id(), #rep{}, filter_type()) -> ok.
 updated_doc(Id, Rep, Filter) ->
-    case compare_replication_records(current_rep(Id), Rep) of
+    case normalize_rep(current_rep(Id)) == normalize_rep(Rep) of
         false ->
             removed_doc(Id),
             Row = #rdoc{
@@ -236,11 +236,6 @@ updated_doc(Id, Rep, Filter) ->
         true ->
             ok
     end.
-
-
--spec compare_replication_records(#rep{}, #rep{}) -> boolean().
-compare_replication_records(Rep1, Rep2) ->
-    normalize_rep(Rep1) == normalize_rep(Rep2).
 
 
 % Return current #rep{} record if any. If replication hasn't been submitted

--- a/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator_doc_processor.erl
@@ -266,13 +266,13 @@ normalize_rep(nil) ->
 
 normalize_rep(#rep{} = Rep)->
     #rep{
-       source = couch_replicator_api_wrap:normalize_db(Rep#rep.source),
-       target = couch_replicator_api_wrap:normalize_db(Rep#rep.target),
-       options = Rep#rep.options,  % already sorted in make_options/1
-       type = Rep#rep.type,
-       view = Rep#rep.view,
-       doc_id = Rep#rep.doc_id,
-       db_name = Rep#rep.db_name
+        source = couch_replicator_api_wrap:normalize_db(Rep#rep.source),
+        target = couch_replicator_api_wrap:normalize_db(Rep#rep.target),
+        options = Rep#rep.options,  % already sorted in make_options/1
+        type = Rep#rep.type,
+        view = Rep#rep.view,
+        doc_id = Rep#rep.doc_id,
+        db_name = Rep#rep.db_name
     }.
 
 

--- a/src/couch_replicator_docs.erl
+++ b/src/couch_replicator_docs.erl
@@ -96,11 +96,11 @@ update_triggered(Rep, {Base, Ext}) ->
     } = Rep,
     StartTimeBin = couch_replicator_utils:iso8601(StartTime),
     update_rep_doc(DbName, DocId, [
-            {<<"_replication_state">>, <<"triggered">>},
-            {<<"_replication_state_reason">>, undefined},
-            {<<"_replication_id">>, iolist_to_binary([Base, Ext])},
-            {<<"_replication_start_time">>, StartTimeBin},
-            {<<"_replication_stats">>, undefined}]),
+        {<<"_replication_state">>, <<"triggered">>},
+        {<<"_replication_state_reason">>, undefined},
+        {<<"_replication_id">>, iolist_to_binary([Base, Ext])},
+        {<<"_replication_start_time">>, StartTimeBin},
+        {<<"_replication_stats">>, undefined}]),
     ok.
 
 
@@ -114,10 +114,10 @@ update_error(#rep{db_name = DbName, doc_id = DocId, id = RepId}, Error) ->
             null
     end,
     update_rep_doc(DbName, DocId, [
-            {<<"_replication_state">>, <<"error">>},
-            {<<"_replication_state_reason">>, Reason},
-            {<<"_replication_stats">>, undefined},
-            {<<"_replication_id">>, BinRepId}]),
+        {<<"_replication_state">>, <<"error">>},
+        {<<"_replication_state_reason">>, Reason},
+        {<<"_replication_stats">>, undefined},
+        {<<"_replication_id">>, BinRepId}]),
     ok.
 
 

--- a/src/couch_replicator_docs.erl
+++ b/src/couch_replicator_docs.erl
@@ -23,6 +23,8 @@
     update_failed/4,
     update_rep_id/1
 ]).
+-export([update_triggered/2, update_error/2]).
+
 
 -define(REP_DB_NAME, <<"_replicator">>).
 -define(REP_DESIGN_DOC, <<"_design/_replicator">>).
@@ -57,6 +59,8 @@ remove_state_fields(DbName, DocId) ->
         {<<"_replication_state">>, undefined},
         {<<"_replication_state_time">>, undefined},
         {<<"_replication_state_reason">>, undefined},
+        {<<"_replication_start_time">>, undefined},
+        {<<"_replication_id">>, undefined},
         {<<"_replication_stats">>, undefined}]).
 
 -spec update_doc_completed(binary(), binary(), [_], erlang:timestamp()) -> any().
@@ -72,19 +76,49 @@ update_doc_completed(DbName, DocId, Stats, StartTime) ->
 
 -spec update_failed(binary(), binary(), any(), erlang:timestamp()) -> any().
 update_failed(DbName, DocId, Error, StartTime) ->
-    Reason = case Error of
-        {bad_rep_doc, Reas} ->
-            Reas;
-        _ ->
-            to_binary(Error)
-    end,
+    Reason = error_reason(Error),
     couch_log:error("Error processing replication doc `~s`: ~s", [DocId, Reason]),
     StartTimeBin = couch_replicator_utils:iso8601(StartTime),
     update_rep_doc(DbName, DocId, [
         {<<"_replication_state">>, <<"failed">>},
         {<<"_replication_start_time">>, StartTimeBin},
+        {<<"_replication_stats">>, undefined},
         {<<"_replication_state_reason">>, Reason}]),
-   couch_stats:increment_counter([couch_replicator, docs, failed_state_updates]).
+    couch_stats:increment_counter([couch_replicator, docs, failed_state_updates]).
+
+
+-spec update_triggered(#rep{}, rep_id()) -> ok.
+update_triggered(Rep, {Base, Ext}) ->
+    #rep{
+        db_name = DbName,
+        doc_id = DocId,
+        start_time = StartTime
+    } = Rep,
+    StartTimeBin = couch_replicator_utils:iso8601(StartTime),
+    update_rep_doc(DbName, DocId, [
+            {<<"_replication_state">>, <<"triggered">>},
+            {<<"_replication_state_reason">>, undefined},
+            {<<"_replication_id">>, iolist_to_binary([Base, Ext])},
+            {<<"_replication_start_time">>, StartTimeBin},
+            {<<"_replication_stats">>, undefined}]),
+    ok.
+
+
+-spec update_error(#rep{}, any()) -> ok.
+update_error(#rep{db_name = DbName, doc_id = DocId, id = RepId}, Error) ->
+    Reason = error_reason(Error),
+    BinRepId = case RepId of
+        {Base, Ext} ->
+            iolist_to_binary([Base, Ext]);
+        _Other ->
+            null
+    end,
+    update_rep_doc(DbName, DocId, [
+            {<<"_replication_state">>, <<"error">>},
+            {<<"_replication_state_reason">>, Reason},
+            {<<"_replication_stats">>, undefined},
+            {<<"_replication_id">>, BinRepId}]),
+    ok.
 
 
 -spec ensure_rep_db_exists() -> {ok, #db{}}.
@@ -458,7 +492,7 @@ convert_options([{<<"doc_ids">>, V} | _R]) when not is_list(V) ->
 convert_options([{<<"doc_ids">>, V} | R]) ->
     % Ensure same behaviour as old replicator: accept a list of percent
     % encoded doc IDs.
-    DocIds = [?l2b(couch_httpd:unquote(Id)) || Id <- V],
+    DocIds = lists:usort([?l2b(couch_httpd:unquote(Id)) || Id <- V]),
     [{doc_ids, DocIds} | convert_options(R)];
 convert_options([{<<"selector">>, V} | _R]) when not is_tuple(V) ->
     throw({bad_request, <<"parameter `selector` must be a JSON object">>});
@@ -624,6 +658,19 @@ strip_credentials(Url) when is_binary(Url) ->
         [{return, binary}]);
 strip_credentials({Props}) ->
     {lists:keydelete(<<"oauth">>, 1, Props)}.
+
+
+error_reason({shutdown, Error}) ->
+    error_reason(Error);
+error_reason({bad_rep_doc, Reason}) ->
+    to_binary(Reason);
+error_reason({error, {Error, Reason}})
+  when is_atom(Error), is_binary(Reason) ->
+    to_binary(io_lib:format("~s: ~s", [Error, Reason]));
+error_reason({error, Reason}) ->
+    to_binary(Reason);
+error_reason(Reason) ->
+    to_binary(Reason).
 
 
 

--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -309,6 +309,12 @@ handle_crashed_job(#job{rep = #rep{db_name = null}} = Job, Reason, _State) ->
 
 handle_crashed_job(Job, Reason, State) ->
     ok = update_state_crashed(Job, Reason, State),
+    case couch_replicator_doc_processor:compat_mode() of
+        true ->
+            couch_replicator_docs:update_error(Job#job.rep, Reason);
+        false ->
+            ok
+    end,
     case ets:info(?MODULE, size) < State#state.max_jobs of
         true ->
             % Starting pending jobs is an O(TotalJobsCount) operation. Only do

--- a/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator_scheduler_job.erl
@@ -486,7 +486,13 @@ format_status(_Opt, [_PDict, State]) ->
 -spec doc_update_triggered(#rep{}) -> ok.
 doc_update_triggered(#rep{db_name = null}) ->
     ok;
-doc_update_triggered(#rep{id = RepId, doc_id = DocId}) ->
+doc_update_triggered(#rep{id = RepId, doc_id = DocId} = Rep) ->
+    case couch_replicator_doc_processor:compat_mode() of
+        true ->
+            couch_replicator_docs:update_triggered(Rep, RepId);
+        false ->
+            ok
+    end,
     couch_log:notice("Document `~s` triggered replication `~s`",
         [DocId, pp_rep_id(RepId)]),
     ok.


### PR DESCRIPTION
Compatibilty mode enables writing of `triggered` and `error` states to the
replication documents. It is designed for backward compatibility with the
previous replicator behavior.

Compatibility mode only affects writing of states to the documents, the
scheduling and backoff as well as the new _scheduler/docs and
_scheduler/jobs HTTP endpoints are not affected by the mode change.

It is possible to switch compatibility mode on and off by toggling the
 `replicator.compatibility_mode` configuration flag between `true` and
 `false` values. Compatibility mode can be switched online, however that
 entails a full rescan of all the replicator shards and possibly updating a
 lot of documents. When compatibility mode is  toggled back from `true` to
 `false` document state fields not applicable to the new scheduling replicator
are cleared. (So both toggling from false to true and true to false could
result in document writes).

Implementation notes:

 * A main idea is avoiding an update feedback cycle,  that is when
 a document state update triggers a replication job update,  which,
 in turn, generates another state update and so on... To avoid this situation a
 semantic short circuit is used: discarad all document updates which do not
 change replication parameters. This includes changes to the _replicator_* fields
 used during state updates, or custom user fields. To accomplish this shortcut,
 introduce the idea of a "normalized" #rep{} record. That is a replication record
 which only has fields set that make it possible to compare 2 instances of rep
 records.

* To make normalization work, some options and other list-based rep fields have
to be sorted. Since options are already sorted, don't sort them again, however,
doc_ids filter was not sorted, so make sure to sort just that.

* In order to toggle the mode at runtime, it is necessary to restart doc
processor and multi-db changes monitor. That is done manually from a spawned-ed
process. The reason it is not done via `{stop,....}` is to keep the logs clean.
(couch_replicator_db_changes termination type was switched to a timeout instead
of brutal_kill as well to keep the logs cleaner on mode switch).

* Since the scheduling replicator might force documents to wait a while in the
pending queue before running them, make sure to update the `triggered` state not
only when jobs started successfully but also when they are added to the
replicator the first time. The preserves the rough semantic of "triggered means
replicator has noticed my document and turned into a replication job" idea.