### PR TITLE
Share replicator connections by proxy

### DIFF
--- a/src/couch_replicator_api_wrap.hrl
+++ b/src/couch_replicator_api_wrap.hrl
@@ -25,7 +25,8 @@
     wait = 250,         % milliseconds
     httpc_pool = nil,
     http_connections,
-    first_error_timestamp = nil
+    first_error_timestamp = nil,
+    proxy_url
 }).
 
 -record(oauth, {

--- a/src/couch_replicator_connection.erl
+++ b/src/couch_replicator_connection.erl
@@ -55,6 +55,9 @@ init([]) ->
     {ok, #state{close_interval=Interval, timer=Timer}}.
 
 
+acquire(URL) when is_binary(URL) ->
+    acquire(binary_to_list(URL));
+
 acquire(URL) ->
     case gen_server:call(?MODULE, {acquire, URL}) of
         {ok, Worker} ->
@@ -85,7 +88,9 @@ handle_call({acquire, URL}, From, State) ->
                     couch_stats:increment_counter([couch_replicator, connection, acquires]),
                     ets:insert(?MODULE, Worker#connection{mref=monitor(process, Pid)}),
                     {reply, {ok, Worker#connection.worker}, State}
-            end
+            end;
+        {error, invalid_uri} ->
+            {reply, {error, invalid_uri}, State}
     end;
 
 handle_call({create, URL, Worker}, From, State) ->

--- a/src/couch_replicator_httpc.erl
+++ b/src/couch_replicator_httpc.erl
@@ -40,8 +40,18 @@
 -define(MAX_DISCARDED_MESSAGES, 16).
 
 
-setup(#httpdb{httpc_pool = nil, url = Url, http_connections = MaxConns} = Db) ->
-    {ok, Pid} = couch_replicator_httpc_pool:start_link(Url, [{max_connections, MaxConns}]),
+setup(Db) ->
+    #httpdb{
+        httpc_pool = nil,
+        url = Url,
+        http_connections = MaxConns,
+        proxy_url = ProxyURL
+    } = Db,
+    HttpcURL = case ProxyURL of
+        undefined -> Url;
+        _ when is_list(ProxyURL) -> ProxyURL
+    end,
+    {ok, Pid} = couch_replicator_httpc_pool:start_link(HttpcURL, [{max_connections, MaxConns}]),
     {ok, Db#httpdb{httpc_pool = Pid}}.
 
 

--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -119,6 +119,12 @@ job_summary(JobId, HealthThreshold) ->
                 {Pid, ErrorCount} when is_pid(Pid) ->
                      {running, null}
             end,
+            StrippedProxyURL = case (Rep#rep.source)#httpdb.proxy_url of
+                undefined ->
+                    null;
+                ProxyURL when is_list(ProxyURL) ->
+                    list_to_binary(couch_util:url_strip_password(ProxyURL))
+            end,
             [
                 {source, iolist_to_binary(ejson_url(Rep#rep.source))},
                 {target, iolist_to_binary(ejson_url(Rep#rep.target))},
@@ -126,7 +132,8 @@ job_summary(JobId, HealthThreshold) ->
                 {info, Info},
                 {error_count, ErrorCount},
                 {last_updated, last_updated(History)},
-                {start_time, couch_replicator_utils:iso8601(Rep#rep.start_time)}
+                {start_time, couch_replicator_utils:iso8601(Rep#rep.start_time)},
+                {proxy, StrippedProxyURL}
             ];
         {error, not_found} ->
             nil  % Job might have just completed

--- a/test/couch_replicator_proxy_tests.erl
+++ b/test/couch_replicator_proxy_tests.erl
@@ -1,0 +1,69 @@
+% Licensed under the Apache License, Version 2.0 (the "License"); you may not
+% use this file except in compliance with the License. You may obtain a copy of
+% the License at
+%
+%   http://www.apache.org/licenses/LICENSE-2.0
+%
+% Unless required by applicable law or agreed to in writing, software
+% distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+% WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+% License for the specific language governing permissions and limitations under
+% the License.
+
+-module(couch_replicator_proxy_tests).
+
+-include_lib("couch/include/couch_eunit.hrl").
+-include_lib("couch_replicator/src/couch_replicator.hrl").
+-include_lib("couch_replicator/src/couch_replicator_api_wrap.hrl").
+
+
+setup() ->
+    ok.
+
+
+teardown(_) ->
+    ok.
+
+
+replicator_proxy_test_() ->
+    {
+        "replicator proxy tests",
+        {
+            setup,
+            fun() -> test_util:start_couch([couch_replicator]) end, fun test_util:stop_couch/1,
+            {
+                foreach,
+                fun setup/0, fun teardown/1,
+                [
+                    fun parse_rep_doc_without_proxy/1,
+                    fun parse_rep_doc_with_proxy/1
+                ]
+            }
+        }
+    }.
+
+
+parse_rep_doc_without_proxy(_) ->
+    ?_test(begin
+        NoProxyDoc = {[
+            {<<"source">>, <<"http://unproxied.com">>},
+            {<<"target">>, <<"http://otherunproxied.com">>}
+        ]},
+        Rep = couch_replicator_docs:parse_rep_doc(NoProxyDoc),
+        ?assertEqual((Rep#rep.source)#httpdb.proxy_url, undefined),
+        ?assertEqual((Rep#rep.target)#httpdb.proxy_url, undefined)
+    end).
+
+
+parse_rep_doc_with_proxy(_) ->
+    ?_test(begin
+        ProxyURL = <<"http://myproxy.com">>,
+        ProxyDoc = {[
+            {<<"source">>, <<"http://unproxied.com">>},
+            {<<"target">>, <<"http://otherunproxied.com">>},
+            {<<"proxy">>, ProxyURL}
+        ]},
+        Rep = couch_replicator_docs:parse_rep_doc(ProxyDoc),
+        ?assertEqual((Rep#rep.source)#httpdb.proxy_url, binary_to_list(ProxyURL)),
+        ?assertEqual((Rep#rep.target)#httpdb.proxy_url, binary_to_list(ProxyURL))
+    end).


### PR DESCRIPTION
Prior to these changes, proxied and unproxied replication connections would be shared based on their source or target. This caused a bug where a proxied connection could function as an unproxied connection if an idle unproxied connection was shared with it.