### PR TITLE
Rename compat_mode config flag to update_docs

### DIFF
--- a/src/couch_replicator_doc_processor.erl
+++ b/src/couch_replicator_doc_processor.erl
@@ -15,7 +15,7 @@
 
 -export([start_link/0]).
 -export([docs/1, doc/2]).
--export([compat_mode/0]).
+-export([update_docs/0]).
 
 % multidb changes callback
 -export([db_created/2, db_deleted/2, db_found/2, db_change/3]).
@@ -32,7 +32,7 @@
     get_json_value/3
 ]).
 
--define(DEFAULT_COMPATIBILITY, false).
+-define(DEFAULT_UPDATE_DOCS, false).
 -define(ERROR_MAX_BACKOFF_EXPONENT, 12).  % ~ 1 day on average
 -define(TS_DAY_SEC, 86400).
 
@@ -125,7 +125,7 @@ process_change(DbName, {Change}) ->
 
 
 maybe_remove_state_fields(DbName, DocId) ->
-    case compat_mode() of
+    case update_docs() of
         true ->
             ok;
         false ->
@@ -345,7 +345,7 @@ worker_returned(Ref, Id, {permanent_failure, _Reason}) ->
 
 -spec maybe_update_doc_error(#rep{}, any()) -> ok.
 maybe_update_doc_error(Rep, Reason) ->
-    case compat_mode() of
+    case update_docs() of
         true ->
             couch_replicator_docs:update_error(Rep, Reason);
         false ->
@@ -354,7 +354,7 @@ maybe_update_doc_error(Rep, Reason) ->
 
 -spec maybe_update_doc_triggered(#rep{}, rep_id()) -> ok.
 maybe_update_doc_triggered(Rep, RepId) ->
-    case compat_mode() of
+    case update_docs() of
         true ->
             couch_replicator_docs:update_triggered(Rep, RepId);
         false ->
@@ -420,9 +420,9 @@ get_worker_wait(#rdoc{state = error, errcnt = ErrCnt}) ->
 get_worker_wait(#rdoc{state = initializing}) ->
     0.
 
--spec compat_mode() -> boolean().
-compat_mode() ->
-    config:get_boolean("replicator", "compatibility_mode", ?DEFAULT_COMPATIBILITY).
+-spec update_docs() -> boolean().
+update_docs() ->
+    config:get_boolean("replicator", "update_docs", ?DEFAULT_UPDATE_DOCS).
 
 
 % _scheduler/docs HTTP endpoint helpers

--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -309,7 +309,7 @@ handle_crashed_job(#job{rep = #rep{db_name = null}} = Job, Reason, _State) ->
 
 handle_crashed_job(Job, Reason, State) ->
     ok = update_state_crashed(Job, Reason, State),
-    case couch_replicator_doc_processor:compat_mode() of
+    case couch_replicator_doc_processor:update_docs() of
         true ->
             couch_replicator_docs:update_error(Job#job.rep, Reason);
         false ->

--- a/src/couch_replicator_scheduler_job.erl
+++ b/src/couch_replicator_scheduler_job.erl
@@ -487,7 +487,7 @@ format_status(_Opt, [_PDict, State]) ->
 doc_update_triggered(#rep{db_name = null}) ->
     ok;
 doc_update_triggered(#rep{id = RepId, doc_id = DocId} = Rep) ->
-    case couch_replicator_doc_processor:compat_mode() of
+    case couch_replicator_doc_processor:update_docs() of
         true ->
             couch_replicator_docs:update_triggered(Rep, RepId);
         false ->


### PR DESCRIPTION
`update_docs` better reflect its functionality. When enabled old replicator
API is still closely emulated, however, there are some new states which could be
written to the document (such as `failed`). Calling it `compat_mode` is thus
misleading.

BugzID: 63012