### PR TITLE
Fix job summary crash for local endpoints

### DIFF
--- a/src/couch_replicator_scheduler.erl
+++ b/src/couch_replicator_scheduler.erl
@@ -119,12 +119,6 @@ job_summary(JobId, HealthThreshold) ->
                 {Pid, ErrorCount} when is_pid(Pid) ->
                      {running, null}
             end,
-            StrippedProxyURL = case (Rep#rep.source)#httpdb.proxy_url of
-                undefined ->
-                    null;
-                ProxyURL when is_list(ProxyURL) ->
-                    list_to_binary(couch_util:url_strip_password(ProxyURL))
-            end,
             [
                 {source, iolist_to_binary(ejson_url(Rep#rep.source))},
                 {target, iolist_to_binary(ejson_url(Rep#rep.target))},
@@ -133,11 +127,18 @@ job_summary(JobId, HealthThreshold) ->
                 {error_count, ErrorCount},
                 {last_updated, last_updated(History)},
                 {start_time, couch_replicator_utils:iso8601(Rep#rep.start_time)},
-                {proxy, StrippedProxyURL}
+                {proxy, job_proxy_url(Rep#rep.source)}
             ];
         {error, not_found} ->
             nil  % Job might have just completed
     end.
+
+
+job_proxy_url(#httpdb{proxy_url = ProxyUrl}) when is_list(ProxyUrl) ->
+    list_to_binary(couch_util:url_strip_password(ProxyUrl));
+
+job_proxy_url(_Endpoint) ->
+    null.
 
 
 -spec health_threshold() -> non_neg_integer().


### PR DESCRIPTION
Previously proxy url manipulation code assumed all endpoints to be remote.