### PR TITLE
Fix job migration during membership change

### DIFF
--- a/src/couch_replicator_db_changes.erl
+++ b/src/couch_replicator_db_changes.erl
@@ -32,7 +32,7 @@ start_link() ->
 
 
 init([]) ->
-    EvtPid = start_link_cluster_event_listener(),
+    EvtPid = couch_replicator_clustering:link_cluster_event_listener(self()),
     State = #state{event_listener = EvtPid, mdb_changes = nil},
     case couch_replicator_clustering:is_stable() of
         true ->
@@ -88,14 +88,3 @@ stop_mdb_changes(#state{mdb_changes = Pid} = State) ->
     unlink(Pid),
     exit(Pid, kill),
     State#state{mdb_changes = nil}.
-
-
--spec start_link_cluster_event_listener() -> pid().
-start_link_cluster_event_listener() ->
-    Server = self(),
-    CallbackFun =
-        fun(Event = {cluster, _}) -> gen_server:cast(Server, Event);
-           (_) -> ok
-        end,
-    {ok, Pid} = couch_replicator_notifier:start_link(CallbackFun),
-    Pid.


### PR DESCRIPTION
Specifically jobs which are in error or crashing state now migrate properly.

Previously jobs migrated only when they checkpointed. Since jobs which are
crashing or trying to fetch their filter code do not checkpoint, they never
migrated and thus could result in duplicate jobs. (New jobs would start on
new node, but jobs would not stop on the old node).

This also simplifies code a bit - removed `no_owner` return value from job
ownership test. Since we do the  check in doc processor all jobs should
have a proper db and doc.