### PR TITLE
Fix ISO8601 timestamp formatting

### DIFF
--- a/src/couch_replicator_utils.erl
+++ b/src/couch_replicator_utils.erl
@@ -141,5 +141,5 @@ parse_rep_doc(Props, UserCtx) ->
 -spec iso8601(erlang:timestamp()) -> binary().
 iso8601({_Mega, _Sec, _Micro} = Timestamp) ->
     {{Y, Mon, D}, {H, Min, S}} = calendar:now_to_universal_time(Timestamp),
-    Format = "~B-~2..0B-~2..0BT~2..0B-~2..0B-~2..0BZ",
+    Format = "~B-~2..0B-~2..0BT~2..0B:~2..0B:~2..0BZ",
     iolist_to_binary(io_lib:format(Format, [Y, Mon, D, H, Min, S])).


### PR DESCRIPTION
`2017-01-16T11-38-04Z` is now `2017-01-16T11:38:04Z`