### PR TITLE
Fix shards db name typo from previous commit

### DIFF
--- a/src/couch_replicator_manager.erl
+++ b/src/couch_replicator_manager.erl
@@ -948,7 +948,7 @@ strip_credentials({Props}) ->
 
 scan_all_dbs(Server) when is_pid(Server) ->
     {ok, Db} = mem3_util:ensure_exists(
-        config:get("mem3", "shard_db", "dbs")),
+        config:get("mem3", "shards_db", "_dbs")),
     ChangesFun = couch_changes:handle_changes(#changes_args{}, nil, Db, nil),
     ChangesFun(fun({change, {Change}, _}, _) ->
         DbName = couch_util:get_value(<<"id">>, Change),


### PR DESCRIPTION
Previous commit which switched to using mem3 for replicator shard
discovery introduced a typo.

 `config:get("mem3", "shard_db", "dbs")`

should be:

 `config:get("mem3", "shards_db", "_dbs")`

COUCHDB-3277