### PR TITLE
Use mem3 in couch_multidb_changes to discover _replicator shards

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ before_install:
 before_script:
   - cd couchdb
   - ./configure --disable-docs --disable-fauxton
+  - rm -rf ./src/couch_replicator/*
   - cp -r ../!(couchdb) ./src/couch_replicator
   - make
 

--- a/src/couch_multidb_changes.erl
+++ b/src/couch_multidb_changes.erl
@@ -674,15 +674,15 @@ t_misc_gen_server_callbacks() ->
 
 scan_dbs_test_() ->
 {
-      foreach,
-      fun() -> test_util:start_couch([mem3, fabric]) end,
-      fun(Ctx) -> test_util:stop_couch(Ctx) end,
-      [
-          t_pass_shard(),
-          t_fail_shard(),
-          t_pass_local(),
-          t_fail_local()
-     ]
+    foreach,
+    fun() -> test_util:start_couch([mem3, fabric]) end,
+    fun(Ctx) -> test_util:stop_couch(Ctx) end,
+    [
+        t_pass_shard(),
+        t_fail_shard(),
+        t_pass_local(),
+        t_fail_local()
+    ]
 }.
 
 
@@ -722,7 +722,7 @@ t_pass_local() ->
 
 
 t_fail_local() ->
- ?_test(begin
+    ?_test(begin
         LocalDb = ?tempdb(),
         {ok, Db} = couch_db:create(LocalDb, [?CTX]),
         ok = couch_db:close(Db),


### PR DESCRIPTION
This is a forward-port of a corresponding commit in master:

"Use mem3 to discover all _replicator shards in replicator manager"

https://github.com/apache/couchdb-couch-replicator/commit/b281d2bb320ed6e6d8226765315a40637ba91a46

This wasn't a direct merge as replicator shard discovery and traversal is slightly
different.

`couch_multidb_changes` is more generic and takes a db suffix and callback
module. So `<<"_replicator">>` is not hard-coded in multidb changes module.

`couch_replicator_manager` handles local `_replicator` db by directly
creating it and launching a changes feed for it. In the scheduling replicator
creation is separate from monitoring. The logic is handled in `scan_all_dbs`
function where first thing it always checks if there is a local db present
matching the suffix, if so a `{resume_scan, DbName}` is sent to main process.
Due to supervisor order by the time that code runs a local replicator db
will be created already.

COUCHDB-3277