### PR TITLE
Add 'source' and 'target' fields to _scheduler/docs terminal states output

### DIFF
--- a/src/couch_replicator_docs.erl
+++ b/src/couch_replicator_docs.erl
@@ -12,7 +12,7 @@
 
 -module(couch_replicator_docs).
 
--export([parse_rep_doc/1, parse_rep_doc/2]).
+-export([parse_rep_doc/1, parse_rep_doc/2, parse_rep_db/3]).
 -export([parse_rep_doc_without_id/1, parse_rep_doc_without_id/2]).
 -export([before_doc_update/2, after_doc_read/2]).
 -export([ensure_rep_db_exists/0, ensure_rep_ddoc_exists/1]).

--- a/src/couch_replicator_js_functions.hrl
+++ b/src/couch_replicator_js_functions.hrl
@@ -176,15 +176,19 @@
     function(doc) {
         state = doc._replication_state;
         if (state === 'failed') {
+            source = doc.source;
+            target = doc.target;
             start_time = doc._replication_start_time;
             last_updated = doc._replication_state_time;
             state_reason = doc._replication_state_reason;
-            emit('failed', [start_time, last_updated, state_reason]);
+            emit('failed', [source, target, start_time, last_updated, state_reason]);
         } else if (state === 'completed') {
+            source = doc.source;
+            target = doc.target;
             start_time = doc._replication_start_time;
             last_updated = doc._replication_state_time;
             stats = doc._replication_stats;
-            emit('completed', [start_time, last_updated, stats]);
+            emit('completed', [source, target, start_time, last_updated, stats]);
         }
     }
 ">>).


### PR DESCRIPTION
Previously terminal states from _scheduler/docs were different from others
as they did not have source and target data in the summary.